### PR TITLE
feat: Daytona Dengue v1 — full pipeline rewrite and post-refactor improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
-# Force LF line endings for scripts executed on Linux
-bin/*.py    text eol=lf
-bin/*.sh    text eol=lf
-*.nf        text eol=lf
-*.config    text eol=lf
+* text=auto eol=lf
+*.gz binary
+*.sif binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ All notable changes to the Daytona Dengue pipeline will be documented in this fi
 
 ---
 
-## [Unreleased] — BPHL GitHub SOP Format Refactor
+## [Unreleased] — Post-refactor improvements
+
+### Changed
+
+- `modules/kraken2.nf` — reverted to bundled viral container (`staphb/kraken2:2.17.1-viral-20251015`); removed `--confidence` filter
+- `nextflow.config` — reduced Kraken2 memory from 50 GB to 8 GB
+- `modules/nextclade.nf` — switched to per-serotype community datasets (`community/v-gen-lab/dengue/denv1–4`)
+- `bin/summary_report.py` — renamed `VADR_flag`/`QC_flag` → `vadr_flag`/`qc_flag`; removed `nextclade_qc_overall` column; improved unclassified/low-coverage QC message; VADR flag derived from QC flag for samples that never reached VADR
+- `bin/qc_gate.py` — updated QC coverage threshold; depth fail message now shows actual observed depth
+- `README.md` — corrected resource requirements; added conda setup step; added Nextflow version constraint note (≥23.04, <26.0); removed estimated runtime
+- `daytona_dengue.sh` — updated SLURM resource allocation
+
+---
+
+## [Unreleased] — SOP Format Refactor
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -1,89 +1,199 @@
 # Daytona Dengue
 
-A Nextflow DSL2 pipeline for Dengue virus NGS data analysis developed at Florida's Bureau of Public Health Laboratories (BPHL).
+<p align="center">
+  <em>⚠️ For research use only. Results were obtained by procedures that were not CLIA validated.</em>
+</p>
 
-The pipeline processes paired-end Illumina reads through quality control, human read removal, adapter trimming, reference-based assembly, variant calling, and sequence annotation. Serotype detection (DENV1–4) is performed inside the pipeline via Kraken2, driving all downstream reference and primer selection automatically. Nextclade provides clade assignment; VADR validates sequences for GenBank submission.
+<p align="center">
+  <img src="https://img.shields.io/badge/Pipeline-Daytona%20Dengue-blue?style=plastic" />
+  <img src="https://img.shields.io/badge/Nextflow-≥23.04-brightgreen?style=plastic&logo=nextflow" />
+  <img src="https://img.shields.io/badge/Python-3.10+-yellow?style=plastic&logo=python" />
+  <img src="https://img.shields.io/badge/License-Apache%202.0-red?style=plastic" />
+</p>
 
-## Directory Structure
+## 🦟🧬 Overview
 
+Daytona Dengue is Florida BPHL's Nextflow pipeline for Dengue virus (DENV) NGS data analysis. It processes paired-end Illumina reads through human read removal, quality control, adapter trimming, reference-based assembly, variant calling, serotype clade assignment and GenBank submission validation.
+
+Serotype detection (DENV1–4) is performed automatically via Kraken2 and coverage-based screening, and drives all downstream reference, primer, and annotation selection. Nextclade provides fine-grained clade assignment using the Hill et al. 2024 dengue lineage system (community/v-gen-lab datasets). VADR validates consensus sequences for GenBank submission.
+
+### ⚙️ Dependencies
+
+- **Nextflow** ≥ 23.04 — [installation guide](https://github.com/nextflow-io/nextflow)
+- **Apptainer/Singularity** — [installation guide](https://apptainer.org/docs/user/latest/)
+- **SLURM** workload manager (required for HiPerGator; optional otherwise)
+
+All bioinformatics tools run inside containers — no additional software installation is required.
+
+### 💻 Resource Requirements
+
+Daytona Dengue is designed to run on an HPC environment but can run locally with sufficient resources.
+
+- **CPUs:** 40 recommended (HPC); minimum 8
+- **RAM:** 200 GB recommended (HPC); 32 GB minimum (Kraken2 requires ~32 GB alone)
+- **Disk:** ~5 GB per sample (input + output); ~8–32 GB for the Kraken2 viral database
+
+**Estimated runtime** (18 samples, 40 CPUs, HPC): ~2–3 hours, dominated by Kraken2 and BWA alignment.
+
+### 🛠️ Setup
+
+#### 1. Configure params.yaml
+
+Edit `params.yaml` and set the input and output paths for your run:
+
+```yaml
+input:  "/full/path/to/fastqs"
+output: "/full/path/to/output"
 ```
-daytona_dengue/
-├── daytona_dengue.nf       # Entry workflow
-├── daytona_dengue.sh       # SLURM submission script
-├── nextflow.config         # All configuration — params, containers, resources, profiles
-├── params.yaml             # Runtime parameters
-├── CHANGELOG.md
-├── README.md
-├── modules/                # One .nf file per tool or tool group
-├── bin/                    # Python helper scripts
-├── assets/
-│   └── annotations/        # Per-serotype GFF annotation files (for iVar)
-├── reference/              # Reference FASTA files + BWA indexes (DENV1–4)
-├── primers/                # Primer BED files (DENV1–4)
-└── fastqs/                 # Place input FASTQ files here
+
+Both `input` and `output` must be absolute paths with no trailing slash.
+
+> **HiPerGator users:** only `input` and `output` need to be set. All other paths are pre-configured in `nextflow.config`.
+> **Non-HiPerGator users:** set `params.kraken_db` in `nextflow.config` (or add it to `params.yaml`) to point to your local Kraken2 viral database directory.
+
+#### 2. Configure daytona_dengue.sh
+
+Set `NXF_APPTAINER_CACHEDIR` to your Apptainer image cache directory and add your email address for job notifications:
+
+```bash
+export NXF_APPTAINER_CACHEDIR=/path/to/apptainer/cache
+#SBATCH --mail-user=your@email.gov
 ```
 
-## Prerequisites
+### How to Run
 
-- [Nextflow](https://github.com/nextflow-io/nextflow) ≥ 23.04
-- [Apptainer](https://apptainer.org/) (recommended for HPC) or Docker
-- SLURM (for HPC runs)
-- A Kraken2 viral database (path set in `params.yaml`)
+Place paired FASTQ files in the directory specified by `params.input`. Both Illumina native (`SAMPLE_S1_L001_R1_001.fastq.gz`) and simplified (`SAMPLE_1.fastq.gz`) naming conventions are supported.
 
-## How to Run
+### 🐊 HiPerGator Usage
 
-### HPC (SLURM + Apptainer)
-
-1. Place paired FASTQ files in `fastqs/`. Files must match either `*_{1,2}.fastq.gz` or `*_R{1,2}_*.fastq.gz` naming.
-2. Edit `params.yaml` — set `input`, `output`, `reference`, `primer`, `annotations`, and `kraken_db` paths.
-3. Edit `daytona_dengue.sh` — set `--mail-user` and `conda activate <your-env>`.
-4. Submit:
 ```bash
 sbatch daytona_dengue.sh
 ```
 
-### Local (Docker)
+### ⚡ Local Usage
 
 ```bash
+# Apptainer/Singularity
+nextflow run daytona_dengue.nf -profile apptainer -params-file params.yaml
+
+# Docker
 nextflow run daytona_dengue.nf -profile docker -params-file params.yaml
 ```
 
-### Local (Singularity/Apptainer)
+### Workflow Diagram
 
-```bash
-nextflow run daytona_dengue.nf -profile apptainer -params-file params.yaml
+```mermaid
+flowchart LR
+    A[Paired FASTQ Input] --> B[FastQC]
+    A --> HS[Human Scrubber]
+    HS --> C[Trimmomatic]
+    C --> D[BBTools\nadapters]
+    D --> E[BBTools\nPhiX]
+    E --> F[FastQC clean]
+    B --> MQ[MultiQC]
+    F --> MQ
+
+    E --> K[Kraken2]
+    E --> BWA[BWA\n4× DENV refs]
+    BWA --> SS[Samtools screen\ncoverage]
+    SS --> SD[Serotype Detect]
+
+    SD --> |DENV1-4| SB[Samtools BAM\nwinning ref]
+    SB --> IT[iVar trim]
+    IT --> SC[Samtools coverage]
+    IT --> SM[Samtools mpileup]
+    SM --> IV[iVar variants]
+    SM --> IC[iVar consensus]
+    IC --> QG[QC Gate]
+
+    QG --> |PASS| VD[VADR]
+    QG --> |PASS| NC[Nextclade\nper-serotype dataset]
+
+    K --> SR[summary_report]
+    SD --> SR
+    SC --> SR
+    IC --> SR
+    NC --> SR
+    VD --> SR
+    QG --> SR
+    SR --> OUT[summary_report.txt]
+
+    style SD fill:#fef,stroke:#333,color:#000
+    style NC fill:#9cf,stroke:#333,color:#000
+    style VD fill:#9cf,stroke:#333,color:#000
+    style SR fill:#f96,stroke:#333,stroke-width:2px,color:#000
+    style OUT fill:#f96,stroke:#333,stroke-width:3px,color:#000
 ```
 
-## Results
+### 🧩 Modules
 
-Per-sample results are written to subdirectories under the `output` path defined in `params.yaml`:
+Daytona Dengue is made possible thanks to the following tools:
+
+<small>
+
+**Quality Control** — [FastQC](https://github.com/s-andrews/FastQC) 0.12.1 · [Trimmomatic](https://github.com/usadellab/Trimmomatic) 0.40 · [BBTools](https://github.com/bbushnell/BBTools) 39.84 · [MultiQC](https://github.com/MultiQC/MultiQC) 1.34
+
+**Human Read Removal** — [NCBI SRA Human Scrubber](https://github.com/ncbi/sra-human-scrubber) 2.2.1
+
+**Taxonomic Classification** — [Kraken2](https://github.com/DerrickWood/kraken2) 2.17.1
+
+**Reference-Based Assembly** — [BWA](https://github.com/lh3/bwa) 0.7.19 · [Samtools](https://github.com/samtools/samtools) 1.23.1 · [iVar](https://github.com/andersen-lab/ivar) 1.4.4
+
+**Clade Assignment** — [Nextclade](https://github.com/nextstrain/nextclade) 3.21.2 · [v-gen-lab dengue datasets](https://github.com/nextstrain/nextclade_data/tree/master/data/community/v-gen-lab/dengue) (Hill et al. 2024)
+
+**Submission Validation** — [VADR](https://github.com/ncbi/vadr) 1.7
+
+</small>
+
+### 📁 Output
+
+Per-sample results are written to `params.output/<sample_id>/`. A single summary file is written to `params.output/`:
 
 ```
 output/
 ├── <sample_id>/
-│   ├── kraken2/
 │   ├── fastqc/
-│   ├── humanscrubber/
 │   ├── trimmomatic/
 │   ├── bbtools/
 │   ├── bwa/
 │   ├── samtools/
 │   ├── ivar/
-│   ├── stats/
 │   ├── vadr/
 │   └── nextclade/
 ├── multiqc/
-└── summary_report.tsv      # Final aggregated report
+└── summary_report.txt
 ```
 
-`summary_report.tsv` contains per-sample serotype, QC metrics, Nextclade clade assignment, and VADR submission result.
+| File | Samples | Key fields |
+|------|---------|------------|
+| `summary_report.txt` | All (including unclassified) | sample_id · serotype · nextclade_clade · nextclade_qc_overall · kraken2_percent · reference · coverage stats · assembly stats · VADR_flag · QC_flag |
 
-## Reference Data
+### 📁 Directory Structure
 
-| File type | Location |
-|---|---|
-| Reference FASTA + BWA indexes | `reference/` |
-| Primer BED files | `primers/` |
-| GFF annotation files (iVar) | `assets/annotations/` |
-| Kraken2 database | External path — set in `params.yaml` |
-| Nextclade dataset | Auto-downloaded and cached (see `nextclade_cache_dir` in `params.yaml`) |
+```text
+daytona_dengue/
+├── daytona_dengue.nf       # Entry workflow
+├── daytona_dengue.sh       # SLURM submission script
+├── nextflow.config         # Container, resource, and profile configuration
+├── params.yaml             # Runtime parameters (input/output paths)
+├── modules/                # One .nf file per tool or tool group
+├── bin/                    # Python helper scripts (QC gate, summary report)
+└── assets/
+    ├── reference/          # Reference FASTA + BWA indexes (DENV1–4)
+    ├── primers/            # Primer BED files (DENV1–4)
+    ├── annotations/        # Per-serotype GFF files (for iVar variants)
+    ├── nextclade/          # Cached Nextclade datasets (auto-downloaded)
+    └── vadr/               # Cached VADR models (auto-downloaded)
+```
+
+### 🤝 Contributing
+
+We welcome contributions to make Daytona Dengue better! Feel free to open issues or submit pull requests to suggest additional features or enhancements.
+
+### 📧 Contact
+
+**Email**: [bphl-sebioinformatics@flhealth.gov](mailto:bphl-sebioinformatics@flhealth.gov)
+
+### ⚖️ License
+
+Daytona Dengue is licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <img src="https://img.shields.io/badge/Pipeline-Daytona%20Dengue-blue?style=plastic" />
   <img src="https://img.shields.io/badge/Nextflow-≥23.04-brightgreen?style=plastic&logo=nextflow" />
   <img src="https://img.shields.io/badge/Python-3.10+-yellow?style=plastic&logo=python" />
-  <img src="https://img.shields.io/badge/License-Apache%202.0-red?style=plastic" />
+  <img src="https://img.shields.io/badge/License-MIT-red?style=plastic" />
 </p>
 
 ## 🦟🧬 Overview
@@ -19,21 +19,23 @@ Serotype detection (DENV1–4) is performed automatically via Kraken2 and covera
 
 ### ⚙️ Dependencies
 
-- **Nextflow** ≥ 23.04 — [installation guide](https://github.com/nextflow-io/nextflow)
+- **Nextflow** 23.04–25.x — [installation guide](https://github.com/nextflow-io/nextflow)
 - **Apptainer/Singularity** — [installation guide](https://apptainer.org/docs/user/latest/)
 - **SLURM** workload manager (required for HiPerGator; optional otherwise)
 
 All bioinformatics tools run inside containers — no additional software installation is required.
 
+> ⚠️ **Nextflow ≥ 26.0 is not supported.** That release introduced breaking changes to DSL2 module parsing. Use Nextflow 23.04–25.x.
+
 ### 💻 Resource Requirements
 
 Daytona Dengue is designed to run on an HPC environment but can run locally with sufficient resources.
 
-- **CPUs:** 40 recommended (HPC); minimum 8
-- **RAM:** 200 GB recommended (HPC); 32 GB minimum (Kraken2 requires ~32 GB alone)
-- **Disk:** ~5 GB per sample (input + output); ~8–32 GB for the Kraken2 viral database
+- **CPUs:** 24 recommended; minimum 8
+- **RAM:** 100 GB recommended; minimum 50 GB (Kraken2 requires ~50 GB to hold the broad database in memory)
+- **Disk:** ~2–3 GB per sample (input + output); ~43 GB for the FL-BPHL Kraken2 database
 
-**Estimated runtime** (18 samples, 40 CPUs, HPC): ~2–3 hours, dominated by Kraken2 and BWA alignment.
+**Estimated runtime** (18 samples, 24 CPUs, 100 GB RAM, HPC): ~26 minutes.
 
 ### 🛠️ Setup
 
@@ -48,8 +50,8 @@ output: "/full/path/to/output"
 
 Both `input` and `output` must be absolute paths with no trailing slash.
 
-> **HiPerGator users:** only `input` and `output` need to be set. All other paths are pre-configured in `nextflow.config`.
-> **Non-HiPerGator users:** set `params.kraken_db` in `nextflow.config` (or add it to `params.yaml`) to point to your local Kraken2 viral database directory.
+> **FL-BPHL / HiPerGator users:** only `input` and `output` need to be set. All other paths are pre-configured in `nextflow.config`.
+> **Non FL-BPHL users:** uncomment the `kraken_db` line in `params.yaml` and set it to your local Kraken2 database directory.
 
 #### 2. Configure daytona_dengue.sh
 
@@ -63,6 +65,8 @@ export NXF_APPTAINER_CACHEDIR=/path/to/apptainer/cache
 ### How to Run
 
 Place paired FASTQ files in the directory specified by `params.input`. Both Illumina native (`SAMPLE_S1_L001_R1_001.fastq.gz`) and simplified (`SAMPLE_1.fastq.gz`) naming conventions are supported.
+
+> At Florida BPHL we use **Apptainer** on HiPerGator. `daytona_dengue.sh` is pre-configured for SLURM + Apptainer on that cluster and is the recommended submission method for FL-BPHL users.
 
 ### 🐊 HiPerGator Usage
 
@@ -83,46 +87,40 @@ nextflow run daytona_dengue.nf -profile docker -params-file params.yaml
 ### Workflow Diagram
 
 ```mermaid
-flowchart LR
-    A[Paired FASTQ Input] --> B[FastQC]
-    A --> HS[Human Scrubber]
-    HS --> C[Trimmomatic]
-    C --> D[BBTools\nadapters]
-    D --> E[BBTools\nPhiX]
-    E --> F[FastQC clean]
-    B --> MQ[MultiQC]
-    F --> MQ
+flowchart TD
+    A([Paired FASTQ Input]) --> B[FASTQC<br/>Raw Read QC]
+    A --> C[HUMAN SCRUBBER<br/>Human Read Removal]
+    C --> D[TRIMMOMATIC<br/>Quality Trimming]
+    D --> E[BBTOOLS<br/>Adapter & PhiX Removal]
+    E --> F[FASTQC<br/>Clean Read QC]
+    B --> G[MULTIQC<br/>Aggregate QC Report]
+    F --> G
+    E --> H[KRAKEN2<br/>Taxonomic Classification]
+    E --> I[BWA<br/>Align to All 4 DENV References]
+    I --> J[SAMTOOLS<br/>Per-Reference Coverage Screen]
+    J --> K{SEROTYPE DETECT<br/>Select Best Reference}
+    K -->|unclassified| L[Excluded from assembly<br/>Reported as FAIL]
+    K -->|DENV 1-4| M[SAMTOOLS<br/>BAM Processing]
+    M --> N[IVAR<br/>Primer Trimming]
+    N --> O[SAMTOOLS<br/>Post-Trim Coverage]
+    N --> P[SAMTOOLS<br/>Mpileup]
+    P --> Q[IVAR<br/>Variant Calling]
+    P --> R[IVAR<br/>Consensus Generation]
+    R --> S{QC GATE<br/>80% genome - 30x depth}
+    S -->|PASS| T[VADR<br/>GenBank Annotation Validation]
+    S -->|PASS| U[NEXTCLADE<br/>Clade Assignment]
+    S -->|FAIL| V[SUMMARY REPORT<br/>summary_report.txt]
+    T --> V
+    U --> V
+    H --> V
+    O --> V
+    L --> V
 
-    E --> K[Kraken2]
-    E --> BWA[BWA\n4× DENV refs]
-    BWA --> SS[Samtools screen\ncoverage]
-    SS --> SD[Serotype Detect]
-
-    SD --> |DENV1-4| SB[Samtools BAM\nwinning ref]
-    SB --> IT[iVar trim]
-    IT --> SC[Samtools coverage]
-    IT --> SM[Samtools mpileup]
-    SM --> IV[iVar variants]
-    SM --> IC[iVar consensus]
-    IC --> QG[QC Gate]
-
-    QG --> |PASS| VD[VADR]
-    QG --> |PASS| NC[Nextclade\nper-serotype dataset]
-
-    K --> SR[summary_report]
-    SD --> SR
-    SC --> SR
-    IC --> SR
-    NC --> SR
-    VD --> SR
-    QG --> SR
-    SR --> OUT[summary_report.txt]
-
-    style SD fill:#fef,stroke:#333,color:#000
-    style NC fill:#9cf,stroke:#333,color:#000
-    style VD fill:#9cf,stroke:#333,color:#000
-    style SR fill:#f96,stroke:#333,stroke-width:2px,color:#000
-    style OUT fill:#f96,stroke:#333,stroke-width:3px,color:#000
+    style A fill:#e1f5e1,color:#000
+    style K fill:#fff4e1,color:#000
+    style S fill:#fff4e1,color:#000
+    style L fill:#ffe1e1,color:#000
+    style V fill:#e1e5ff,color:#000,stroke-width:2px
 ```
 
 ### 🧩 Modules
@@ -166,7 +164,7 @@ output/
 
 | File | Samples | Key fields |
 |------|---------|------------|
-| `summary_report.txt` | All (including unclassified) | sample_id · serotype · nextclade_clade · nextclade_qc_overall · kraken2_percent · reference · coverage stats · assembly stats · VADR_flag · QC_flag |
+| `summary_report.txt` | All (including unclassified) | sample_id · serotype · nextclade_clade · kraken2_percent · reference · coverage stats · assembly stats · VADR_flag · QC_flag |
 
 ### 📁 Directory Structure
 
@@ -196,4 +194,4 @@ We welcome contributions to make Daytona Dengue better! Feel free to open issues
 
 ### ⚖️ License
 
-Daytona Dengue is licensed under the [Apache License 2.0](LICENSE).
+Daytona Dengue is licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Daytona Dengue is made possible thanks to the following tools:
 
 Per-sample results are written to `params.output/<sample_id>/`. A single summary file is written to `params.output/`:
 
-```
+```markdown
 output/
 ├── <sample_id>/
 │   ├── fastqc/

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@
 
 Daytona Dengue is Florida BPHL's Nextflow pipeline for Dengue virus (DENV) NGS data analysis. It processes paired-end Illumina reads through human read removal, quality control, adapter trimming, reference-based assembly, variant calling, serotype clade assignment and GenBank submission validation.
 
-Serotype detection (DENV1–4) is performed automatically via Kraken2 and coverage-based screening, and drives all downstream reference, primer, and annotation selection. Nextclade provides fine-grained clade assignment using the Hill et al. 2024 dengue lineage system (community/v-gen-lab datasets). VADR validates consensus sequences for GenBank submission.
+Serotype detection (DENV1–4) is performed automatically via Kraken2 and coverage-based screening, and drives all downstream reference, primer and annotation selection. Nextclade provides fine-grained clade assignment using the [Hill et al. 2024 dengue lineage system (community/v-gen-lab datasets)](https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.3002834). VADR validates consensus sequences for GenBank submission.
 
 ### ⚙️ Dependencies
 
-- **Nextflow** 23.04–25.x — [installation guide](https://github.com/nextflow-io/nextflow)
-- **Apptainer/Singularity** — [installation guide](https://apptainer.org/docs/user/latest/)
-- **SLURM** workload manager (required for HiPerGator; optional otherwise)
+- **Nextflow** 23.04–25.x - [installation guide](https://github.com/nextflow-io/nextflow)
+- **Apptainer/Singularity** - [installation guide](https://apptainer.org/docs/user/latest/)
+- **SLURM** workload manager (required for HiPerGator; otherwise not required)
 
-All bioinformatics tools run inside containers — no additional software installation is required.
+All bioinformatics tools run inside containers, no additional software installation is required.
 
 > ⚠️ **Nextflow ≥ 26.0 is not supported.** That release introduced breaking changes to DSL2 module parsing. Use Nextflow 23.04–25.x.
 
@@ -50,10 +50,13 @@ output: "/full/path/to/output"
 
 Both `input` and `output` must be absolute paths with no trailing slash.
 
-> **FL-BPHL / HiPerGator users:** only `input` and `output` need to be set. All other paths are pre-configured in `nextflow.config`.
-> **Non FL-BPHL users:** uncomment the `kraken_db` line in `params.yaml` and set it to your local Kraken2 database directory.
+##### FL-BPHL users:** only `input` and `output` need to be set. All other paths are pre-configured in `nextflow.config`.
+
+##### Non FL-BPHL users:** uncomment the `kraken_db` line in `params.yaml` and set it to your local Kraken2 database directory. Kraken2 databases are available for download [here](https://benlangmead.github.io/aws-indexes/k2) 
 
 #### 2. Configure daytona_dengue.sh
+
+> At Florida BPHL we use **Apptainer** on HiPerGator. `daytona_dengue.sh` is pre-configured for SLURM + Apptainer and is the recommended submission method for FL-BPHL users.
 
 Set `NXF_APPTAINER_CACHEDIR` to your Apptainer image cache directory and add your email address for job notifications:
 
@@ -65,8 +68,6 @@ export NXF_APPTAINER_CACHEDIR=/path/to/apptainer/cache
 ### How to Run
 
 Place paired FASTQ files in the directory specified by `params.input`. Both Illumina native (`SAMPLE_S1_L001_R1_001.fastq.gz`) and simplified (`SAMPLE_1.fastq.gz`) naming conventions are supported.
-
-> At Florida BPHL we use **Apptainer** on HiPerGator. `daytona_dengue.sh` is pre-configured for SLURM + Apptainer on that cluster and is the recommended submission method for FL-BPHL users.
 
 ### 🐊 HiPerGator Usage
 
@@ -129,17 +130,17 @@ Daytona Dengue is made possible thanks to the following tools:
 
 <small>
 
-**Quality Control** — [FastQC](https://github.com/s-andrews/FastQC) 0.12.1 · [Trimmomatic](https://github.com/usadellab/Trimmomatic) 0.40 · [BBTools](https://github.com/bbushnell/BBTools) 39.84 · [MultiQC](https://github.com/MultiQC/MultiQC) 1.34
+**Quality Control**: [FastQC](https://github.com/s-andrews/FastQC) 0.12.1 · [Trimmomatic](https://github.com/usadellab/Trimmomatic) 0.40 · [BBTools](https://github.com/bbushnell/BBTools) 39.84 · [MultiQC](https://github.com/MultiQC/MultiQC) 1.34
 
-**Human Read Removal** — [NCBI SRA Human Scrubber](https://github.com/ncbi/sra-human-scrubber) 2.2.1
+**Human Read Removal**: [NCBI SRA Human Scrubber](https://github.com/ncbi/sra-human-scrubber) 2.2.1
 
-**Taxonomic Classification** — [Kraken2](https://github.com/DerrickWood/kraken2) 2.17.1
+**Taxonomic Classification**: [Kraken2](https://github.com/DerrickWood/kraken2) 2.17.1
 
-**Reference-Based Assembly** — [BWA](https://github.com/lh3/bwa) 0.7.19 · [Samtools](https://github.com/samtools/samtools) 1.23.1 · [iVar](https://github.com/andersen-lab/ivar) 1.4.4
+**Reference-Based Assembly**: [BWA](https://github.com/lh3/bwa) 0.7.19 · [Samtools](https://github.com/samtools/samtools) 1.23.1 · [iVar](https://github.com/andersen-lab/ivar) 1.4.4
 
-**Clade Assignment** — [Nextclade](https://github.com/nextstrain/nextclade) 3.21.2 · [v-gen-lab dengue datasets](https://github.com/nextstrain/nextclade_data/tree/master/data/community/v-gen-lab/dengue) (Hill et al. 2024)
+**Clade Assignment**: [Nextclade](https://github.com/nextstrain/nextclade) 3.21.2 · [v-gen-lab dengue datasets](https://github.com/nextstrain/nextclade_data/tree/master/data/community/v-gen-lab/dengue) (Hill et al. 2024)
 
-**Submission Validation** — [VADR](https://github.com/ncbi/vadr) 1.7
+**Submission Validation**: [VADR](https://github.com/ncbi/vadr) 1.7
 
 </small>
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Serotype detection (DENV1–4) is performed automatically via Kraken2 and covera
 
 - **Nextflow** 23.04–25.x - [installation guide](https://github.com/nextflow-io/nextflow)
 - **Apptainer/Singularity** - [installation guide](https://apptainer.org/docs/user/latest/)
+- **Conda** - [installation guide](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html)
 - **SLURM** workload manager (required for HiPerGator; otherwise not required)
+
 
 All bioinformatics tools run inside containers, no additional software installation is required.
 
@@ -32,14 +34,21 @@ All bioinformatics tools run inside containers, no additional software installat
 Daytona Dengue is designed to run on an HPC environment but can run locally with sufficient resources.
 
 - **CPUs:** 24 recommended; minimum 8
-- **RAM:** 100 GB recommended; minimum 50 GB (Kraken2 requires ~50 GB to hold the broad database in memory)
-- **Disk:** ~2–3 GB per sample (input + output); ~43 GB for the FL-BPHL Kraken2 database
+- **RAM:** 100 GB recommended; minimum 32 GB
+- **Disk:** ~2–3 GB per sample (input + output)
 
 **Estimated runtime** (18 samples, 24 CPUs, 100 GB RAM, HPC): ~26 minutes.
 
 ### 🛠️ Setup
 
-#### 1. Configure params.yaml
+#### 1. Create the conda environment
+
+```bash
+$ conda create -n daytona_dengue -c conda-forge python=3.10
+
+```
+
+#### 2. Configure params.yaml
 
 Edit `params.yaml` and set the input and output paths for your run:
 
@@ -50,13 +59,9 @@ output: "/full/path/to/output"
 
 Both `input` and `output` must be absolute paths with no trailing slash.
 
-##### FL-BPHL users:** only `input` and `output` need to be set. All other paths are pre-configured in `nextflow.config`.
+#### 3. Configure daytona_dengue.sh
 
-##### Non FL-BPHL users:** uncomment the `kraken_db` line in `params.yaml` and set it to your local Kraken2 database directory. Kraken2 databases are available for download [here](https://benlangmead.github.io/aws-indexes/k2) 
-
-#### 2. Configure daytona_dengue.sh
-
-> At Florida BPHL we use **Apptainer** on HiPerGator. `daytona_dengue.sh` is pre-configured for SLURM + Apptainer and is the recommended submission method for FL-BPHL users.
+> At Florida BPHL we use **Apptainer** on HiPerGator for containerization. `daytona_dengue.sh` is pre-configured for SLURM + Apptainer and is the recommended submission method for FL-BPHL users.
 
 Set `NXF_APPTAINER_CACHEDIR` to your Apptainer image cache directory and add your email address for job notifications:
 

--- a/README.md
+++ b/README.md
@@ -170,24 +170,6 @@ output/
 |------|---------|------------|
 | `summary_report.txt` | All (including unclassified) | sample_id · serotype · nextclade_clade · kraken2_percent · reference · coverage stats · assembly stats · VADR_flag · QC_flag |
 
-### 📁 Directory Structure
-
-```text
-daytona_dengue/
-├── daytona_dengue.nf       # Entry workflow
-├── daytona_dengue.sh       # SLURM submission script
-├── nextflow.config         # Container, resource, and profile configuration
-├── params.yaml             # Runtime parameters (input/output paths)
-├── modules/                # One .nf file per tool or tool group
-├── bin/                    # Python helper scripts (QC gate, summary report)
-└── assets/
-    ├── reference/          # Reference FASTA + BWA indexes (DENV1–4)
-    ├── primers/            # Primer BED files (DENV1–4)
-    ├── annotations/        # Per-serotype GFF files (for iVar variants)
-    ├── nextclade/          # Cached Nextclade datasets (auto-downloaded)
-    └── vadr/               # Cached VADR models (auto-downloaded)
-```
-
 ### 🤝 Contributing
 
 We welcome contributions to make Daytona Dengue better! Feel free to open issues or submit pull requests to suggest additional features or enhancements.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ Daytona Dengue is designed to run on an HPC environment but can run locally with
 - **RAM:** 50 GB recommended; minimum 16 GB
 - **Disk:** ~2–3 GB per sample (input + output)
 
-**Estimated runtime** (18 samples, 24 CPUs, 100 GB RAM, HPC): ~26 minutes.
-
 ### 🛠️ Setup
 
 #### 1. Create the conda environment

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ All bioinformatics tools run inside containers, no additional software installat
 Daytona Dengue is designed to run on an HPC environment but can run locally with sufficient resources.
 
 - **CPUs:** 24 recommended; minimum 8
-- **RAM:** 100 GB recommended; minimum 32 GB
+- **RAM:** 50 GB recommended; minimum 16 GB
 - **Disk:** ~2–3 GB per sample (input + output)
 
 **Estimated runtime** (18 samples, 24 CPUs, 100 GB RAM, HPC): ~26 minutes.

--- a/bin/qc_gate.py
+++ b/bin/qc_gate.py
@@ -5,17 +5,14 @@ qc_gate.py — Compute QC pass/fail for a dengue consensus assembly.
 Reads samtools coverage output and the consensus FASTA.
 Writes a 2-column TSV: sample_id, qc_flag.
 
-This script exists solely to produce the QC decision needed to gate
-downstream VADR annotation. All full reporting is handled by summary_report.py.
-
-QC thresholds (hardcoded):
-    percent_ref_genome_cov >= 80%  AND  mean_depth >= 30x  → PASS
+QC thresholds:
+    percent_ref_genome_cov >= 5%  AND  mean_depth >= 30x  → PASS
 """
 
 import argparse
 import sys
 
-QC_MIN_COVERAGE = 80.0
+QC_MIN_COVERAGE = 5.0
 QC_MIN_DEPTH    = 30.0
 
 
@@ -56,7 +53,7 @@ def main():
     if pct_genome < QC_MIN_COVERAGE:
         flag = f"FAIL: Percent genome < {int(QC_MIN_COVERAGE)}%"
     elif mean_depth < QC_MIN_DEPTH:
-        flag = f"FAIL: Mean read depth < {int(QC_MIN_DEPTH)}x"
+        flag = f"FAIL: Low depth ({mean_depth:.1f}x)"
     else:
         flag = 'PASS'
 

--- a/bin/summary_report.py
+++ b/bin/summary_report.py
@@ -296,7 +296,7 @@ def main():
 
     header = [
         "sample_id", "serotype",
-        "nextclade_clade", "nextclade_qc_overall",
+        "nextclade_clade",
         "kraken2_percent",
         "reference", "start", "end",
         "num_raw_reads", "num_clean_reads", "num_mapped_reads", "percent_mapped_clean_reads",
@@ -336,6 +336,9 @@ def main():
         else:
             qf = qc.get(sid, "NA")
 
+        if vf == "NA" and qf.startswith("FAIL"):
+            vf = "FAIL"
+
         raw_reads   = trimstats.get(sid, "NA")
         clean_reads = phix_log.get(sid, "NA")
 
@@ -352,14 +355,10 @@ def main():
         called   = con.get("_seq_called", 0)
         pct_ref  = f"{(called / ref_len * 100):.4f}" if ref_len > 0 and not unclassified else "NA"
 
-        _nc_qc_raw = nc.get("qc.overallStatus", "NA") or "NA"
-        _nc_qc     = "error" if (_nc_qc_raw == "NA" and nc.get("errors", "").strip()) else _nc_qc_raw
-
         row = {
             "sample_id":                     sid,
             "serotype":                      sero,
-            "nextclade_clade":               nc.get("clade", "NA") or "NA",
-            "nextclade_qc_overall":          _nc_qc,
+            "nextclade_clade":               nc.get("clade", "") or "unclassified",
             "kraken2_percent":               k2,
             "reference":                     cov.get("reference", "NA"),
             "start":                         cov.get("start", "NA"),

--- a/bin/summary_report.py
+++ b/bin/summary_report.py
@@ -303,7 +303,7 @@ def main():
         "cov_bases_mapped", "percent_genome_cov_map",
         "mean_depth", "mean_base_qual", "mean_map_qual",
         "assembly_length", "numN", "percent_ref_genome_cov",
-        "VADR_flag", "QC_flag",
+        "vadr_flag", "qc_flag",
     ]
 
     _REF_SERO = {
@@ -328,9 +328,9 @@ def main():
             _best_pct  = cov.get("percent_genome_cov_map")
             _best_sero = _REF_SERO.get((cov.get("reference") or "").split()[0], "")
             if _best_pct and _best_sero:
-                qf = f"FAIL: Unclassified (best: {float(_best_pct):.1f}% {_best_sero})"
+                qf = f"FAIL: Low coverage (best: {float(_best_pct):.1f}% {_best_sero})"
             elif _best_pct:
-                qf = f"FAIL: Unclassified (best coverage: {float(_best_pct):.1f}%)"
+                qf = f"FAIL: Low coverage (best: {float(_best_pct):.1f}%)"
             else:
                 qf = "FAIL: Unclassified"
         else:
@@ -375,8 +375,8 @@ def main():
             "assembly_length":               con.get("assembly_length", "NA"),
             "numN":                          con.get("numN", "NA"),
             "percent_ref_genome_cov":        pct_ref,
-            "VADR_flag":                     vf,
-            "QC_flag":                       qf,
+            "vadr_flag":                     vf,
+            "qc_flag":                       qf,
         }
         rows.append(row)
 

--- a/bin/summary_report.py
+++ b/bin/summary_report.py
@@ -306,6 +306,13 @@ def main():
         "VADR_flag", "QC_flag",
     ]
 
+    _REF_SERO = {
+        "NC_001477.1": "DENV1",
+        "NC_001474.2": "DENV2",
+        "NC_001475.2": "DENV3",
+        "NC_002640.1": "DENV4",
+    }
+
     rows = []
     for sid in all_samples:
         sero = serotype.get(sid, "NA")
@@ -316,7 +323,18 @@ def main():
         nc  = {} if unclassified else nextclade.get(sid, {})
         vf  = "NA" if unclassified else vadr.get(sid, "NA")
         k2  = kraken2.get(sid, "NA")
-        qf  = "FAIL: Unclassified" if unclassified else qc.get(sid, "NA")
+
+        if unclassified:
+            _best_pct  = cov.get("percent_genome_cov_map")
+            _best_sero = _REF_SERO.get((cov.get("reference") or "").split()[0], "")
+            if _best_pct and _best_sero:
+                qf = f"FAIL: Unclassified (best: {float(_best_pct):.1f}% {_best_sero})"
+            elif _best_pct:
+                qf = f"FAIL: Unclassified (best coverage: {float(_best_pct):.1f}%)"
+            else:
+                qf = "FAIL: Unclassified"
+        else:
+            qf = qc.get(sid, "NA")
 
         raw_reads   = trimstats.get(sid, "NA")
         clean_reads = phix_log.get(sid, "NA")
@@ -330,15 +348,18 @@ def main():
         else:
             pct_mapped = "NA"
 
-        ref_len = int(cov.get("end", 0) or 0)
-        called  = con.get("_seq_called", 0)
-        pct_ref = f"{(called / ref_len * 100):.4f}" if ref_len > 0 and not unclassified else "NA"
+        ref_len  = int(cov.get("end", 0) or 0)
+        called   = con.get("_seq_called", 0)
+        pct_ref  = f"{(called / ref_len * 100):.4f}" if ref_len > 0 and not unclassified else "NA"
+
+        _nc_qc_raw = nc.get("qc.overallStatus", "NA") or "NA"
+        _nc_qc     = "error" if (_nc_qc_raw == "NA" and nc.get("errors", "").strip()) else _nc_qc_raw
 
         row = {
             "sample_id":                     sid,
             "serotype":                      sero,
-            "nextclade_clade":               nc.get("clade", "NA"),
-            "nextclade_qc_overall":          nc.get("qc.overallStatus", "NA"),
+            "nextclade_clade":               nc.get("clade", "NA") or "NA",
+            "nextclade_qc_overall":          _nc_qc,
             "kraken2_percent":               k2,
             "reference":                     cov.get("reference", "NA"),
             "start":                         cov.get("start", "NA"),

--- a/daytona_dengue.nf
+++ b/daytona_dengue.nf
@@ -3,7 +3,7 @@
 /*
   Daytona Dengue
   Florida's BPHL Nextflow pipeline for Dengue virus NGS data analysis
-  Authors: Yibo Dong, Arnold Rodriguez
+  Authors: Yibo Dong, Arnold Rodriguez, Molly Mitchell
   Email: bphl-sebioinformatics@flhealth.gov
 */
 

--- a/daytona_dengue.sh
+++ b/daytona_dengue.sh
@@ -3,16 +3,16 @@
 #SBATCH --qos=bphl-umbrella
 #SBATCH --job-name=daytona_dengue
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=40
-#SBATCH --mem=200gb
-#SBATCH --time=48:00:00
+#SBATCH --cpus-per-task=24
+#SBATCH --mem=100gb
+#SBATCH --time=04:00:00
 #SBATCH --output=daytona_dengue.%j.out
 #SBATCH --error=daytona_dengue.%j.err
 #SBATCH --mail-user=<EMAIL>
 #SBATCH --mail-type=FAIL,END
 
-module load conda nextflow apptainer
-conda activate PIPELINE_ENV
+module load conda apptainer nextflow/25.10.4
+conda activate daytona_dengue
 
 # Path to container image cache directory
 export NXF_APPTAINER_CACHEDIR=/path/to/apptainer/cache

--- a/modules/kraken2.nf
+++ b/modules/kraken2.nf
@@ -10,8 +10,7 @@ process kraken2 {
     script:
     """
     kraken2 \\
-        --db ${params.kraken_db} \\
-        --confidence 0.5 \\
+        --db /kraken2-db \\
         --threads ${task.cpus} \\
         --paired \\
         --output /dev/null \\

--- a/modules/kraken2.nf
+++ b/modules/kraken2.nf
@@ -10,7 +10,7 @@ process kraken2 {
     script:
     """
     kraken2 \\
-        --db /kraken2-db \\
+        --db ${params.kraken_db} \\
         --confidence 0.5 \\
         --threads ${task.cpus} \\
         --paired \\

--- a/modules/nextclade.nf
+++ b/modules/nextclade.nf
@@ -11,7 +11,7 @@ process nextclade_download {
     def name = sero.toLowerCase()
     """
     nextclade dataset get \\
-        --name "nextstrain/dengue/${name}" \\
+        --name "community/v-gen-lab/dengue/${name}" \\
         --output-dir nextclade_dataset
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -38,7 +38,7 @@ process {
     withName: kraken2 {
         container = 'docker://staphb/kraken2:2.17.1-viral-20251015'
         cpus      = 8
-        memory    = 50.GB
+        memory    = 8.GB
     }
     withName: bwa {
         container = 'docker://staphb/bwa:0.7.19'

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,11 +1,3 @@
-params {
-    kraken_db = "/orange/bphl-florida/databases/kraken_databases/kraken2-broad-custom_other-20200411"
-}
-
-manifest {
-    nextflowVersion = '>=23.04 <26.0'
-}
-
 // Process-specific configs — container, cpus, memory per tool
 process {
     withName: fastqc {
@@ -44,7 +36,7 @@ process {
         memory    = 4.GB
     }
     withName: kraken2 {
-        container = 'docker://staphb/kraken2:2.17.1'
+        container = 'docker://staphb/kraken2:2.17.1-viral-20251015'
         cpus      = 8
         memory    = 50.GB
     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,3 +1,11 @@
+params {
+    kraken_db = "/orange/bphl-florida/databases/kraken_databases/kraken2-broad-custom_other-20200411"
+}
+
+manifest {
+    nextflowVersion = '>=23.04 <26.0'
+}
+
 // Process-specific configs — container, cpus, memory per tool
 process {
     withName: fastqc {
@@ -36,9 +44,9 @@ process {
         memory    = 4.GB
     }
     withName: kraken2 {
-        container = 'docker://staphb/kraken2:2.17.1-viral-20251015'
+        container = 'docker://staphb/kraken2:2.17.1'
         cpus      = 8
-        memory    = 32.GB
+        memory    = 50.GB
     }
     withName: bwa {
         container = 'docker://staphb/bwa:0.7.19'

--- a/params.yaml
+++ b/params.yaml
@@ -1,5 +1,7 @@
-# input:  directory containing paired FASTQ files, absolute paths, no trailing slash
-# output: directory where all results will be written, absolute paths, no trailing slash
+# Input / Output absolute paths, no trailing slash "/"
 
 input:  "/full/path/to/fastqs"
 output: "/full/path/to/output"
+
+# Non FL-BPHL users: uncomment and set the path to your Kraken2 database
+# kraken_db: "/path/to/your/kraken2/database"

--- a/params.yaml
+++ b/params.yaml
@@ -1,7 +1,3 @@
 # Input / Output absolute paths, no trailing slash "/"
-
 input:  "/full/path/to/fastqs"
 output: "/full/path/to/output"
-
-# Non FL-BPHL users: uncomment and set the path to your Kraken2 database
-# kraken_db: "/path/to/your/kraken2/database"


### PR DESCRIPTION
## Summary

- Rewrote pipeline to DSL2 with meta-driven channel design; replaces all legacy
  if/elif serotype blocks with a single unified workflow
- Switched Nextclade to per-serotype community datasets (community/v-gen-lab/dengue/denv1–4)
  for fine-grained clade assignment (Hill et al. 2024)
- Reverted Kraken2 to bundled viral container (staphb/kraken2:2.17.1-viral-20251015);
  removed --confidence filter; reduced memory allocation to 8 GB
- Summary report: renamed VADR_flag/QC_flag → vadr_flag/qc_flag; removed
  nextclade_qc_overall column; improved unclassified/low-coverage QC messages;
  VADR flag derived from QC flag for samples that never reached VADR
- Updated QC coverage threshold and depth fail message to show actual observed depth
- Updated README: corrected resource requirements, added conda setup step,
  added Nextflow version constraint note (≥23.04, <26.0)
- Added .gitattributes to enforce LF line endings